### PR TITLE
fix: correct TOML formatting for build.processing sections

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -56,18 +56,23 @@
 [[plugins]]
   package = "@netlify/plugin-nextjs"
 
+# Processing configuration
 [build.processing]
-  skip_processing = false
-  [build.processing.css]
-    bundle = true
-    minify = true
-  [build.processing.js]
-    bundle = true
-    minify = true
-  [build.processing.html]
-    pretty_urls = true
-  [build.processing.images]
-    compress = true
+skip_processing = false
+
+[build.processing.css]
+bundle = true
+minify = true
+
+[build.processing.js]
+bundle = true
+minify = true
+
+[build.processing.html]
+pretty_urls = true
+
+[build.processing.images]
+compress = true
 
 # Function configuration
 [functions]


### PR DESCRIPTION
- Properly structure build.processing and its subsections
- Remove indentation from section headers to fix TOML parsing